### PR TITLE
Add type integer for pin_priority

### DIFF
--- a/providers/preference.rb
+++ b/providers/preference.rb
@@ -39,7 +39,7 @@ action :add do
     action :nothing
   end
 
-  preference_file = file "/etc/apt/preferences.d/#{new_resource.name}" do
+  preference_file = file "/etc/apt/preferences.d/#{new_resource.name}.pref" do
     owner 'root'
     group 'root'
     mode 00644

--- a/resources/preference.rb
+++ b/resources/preference.rb
@@ -29,4 +29,4 @@ end
 attribute :package_name, :kind_of => String, :name_attribute => true
 attribute :glob, :kind_of => String
 attribute :pin, :kind_of => String
-attribute :pin_priority, :kind_of => String
+attribute :pin_priority, :kind_of => [String, Integer]


### PR DESCRIPTION
I think the pin_priority should be only Integer type, but for backwards compatibility I make it String or Integer.