### PR TITLE
Quote repository URI if it contains a space

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -83,6 +83,7 @@ end
 
 # build repo file contents
 def build_repo(uri, distribution, components, trusted, arch, add_deb_src)
+  uri = '"' + uri + '"' if uri.match(' ')
   components = components.join(' ') if components.respond_to?(:join)
   repo_options = []
   repo_options << "arch=#{arch}" if arch


### PR DESCRIPTION
It's possible to have spaces in the repository URI, and APT properly handles quotes in that scenario.