### PR TITLE
Update unatteneded-upgrades template attribute reference to match name used in attribute file

### DIFF
--- a/templates/default/20auto-upgrades.erb
+++ b/templates/default/20auto-upgrades.erb
@@ -1,2 +1,2 @@
 APT::Periodic::Update-Package-Lists "<%= node['apt']['unattended_upgrades']['update_package_lists'] ? 1 : 0 %>";
-APT::Periodic::Unattended-Upgrade "<%= node['apt']['unattended_upgrades']['enabled'] ? 1 : 0 %>";
+APT::Periodic::Unattended-Upgrade "<%= node['apt']['unattended_upgrades']['enable'] ? 1 : 0 %>";


### PR DESCRIPTION
The template used `enabled`, however the default attributes used `enable`.

This unifies both on using `enable` as the attribute name.