### PR TITLE
Ignore failure installing update-notifier-common

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -75,6 +75,7 @@ end
 package 'update-notifier-common' do
   notifies :run, 'execute[apt-get-update]', :immediately
   only_if { apt_installed? }
+  ignore_failure true
 end
 
 execute 'apt-get-update-periodic' do


### PR DESCRIPTION
This workaround fix apt error on Debian jessie. It is not a real
solution, but it allow to test in development environments