### PR TITLE
Add support for SSL-enabled apt servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Attributes
 * `['apt']['cacher_ipaddress']` - use a cacher server (or standard proxy server) not available via search
 * `['apt']['cacher_interface]` - interface to connect to the cacher-ng service, no default.
 * `['apt']['cacher_port']` - port for the cacher-ng service (either client or server), default is '3142'
+* `['apt']['cacher_ssl_support']` - indicates whether the cacher supports upstream SSL servers, default is 'false'
 * `['apt']['cacher_dir']` - directory used by cacher-ng service, default is '/var/cache/apt-cacher-ng'
 * `['apt']['cacher-client']['restrict_environment']` - restrict your node to using the `apt-cacher-ng` server in your Environment, default is 'false'
 * `['apt']['compiletime']` - force the `cacher-client` recipe to run before other recipes. It forces apt to use the proxy before other recipes run. Useful if your nodes have limited access to public apt repositories. This is overridden if the `cacher-ng` recipe is in your run list. Default is 'false'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,7 @@ default['apt']['cacher-client']['restrict_environment'] = false
 default['apt']['cacher_dir'] = '/var/cache/apt-cacher-ng'
 default['apt']['cacher_interface'] = nil
 default['apt']['cacher_port'] = 3142
+default['apt']['cacher_ssl_support'] = false
 default['apt']['caching_server'] = false
 default['apt']['compiletime'] = false
 default['apt']['compile_time_update'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -21,6 +21,10 @@ attribute 'apt/cacher_port',
           :description => 'Default listen port for the caching server',
           :default => '3142'
 
+attribute 'apt/cacher_ssl_support',
+          :description => 'The caching server supports upstream SSL servers via CONNECT',
+          :default => 'false'
+
 attribute 'apt/cacher_interface',
           :description => 'Default listen interface for the caching server',
           :default => nil

--- a/recipes/cacher-client.rb
+++ b/recipes/cacher-client.rb
@@ -65,6 +65,7 @@ if servers.length > 0
     variables(
       :proxy => cacher_ipaddress,
       :port => servers[0]['apt']['cacher_port'],
+      :proxy_ssl => servers[0]['apt']['cacher_ssl_support'],
       :bypass => node['apt']['cache_bypass']
       )
     action(node['apt']['compiletime'] ? :nothing : :create)

--- a/recipes/cacher-client.rb
+++ b/recipes/cacher-client.rb
@@ -36,6 +36,7 @@ if node['apt']
     cacher.default.ipaddress = node['apt']['cacher_ipaddress']
     cacher.default.apt.cacher_port = node['apt']['cacher_port']
     cacher.default.apt_cacher_interface = node['apt']['cacher_interface']
+    cacher.default.apt.cacher_ssl_support = node['apt']['cacher_ssl_support']
     servers << cacher
   elsif node['apt']['caching_server']
     node.override['apt']['compiletime'] = false

--- a/recipes/cacher-client.rb
+++ b/recipes/cacher-client.rb
@@ -35,7 +35,7 @@ if node['apt']
     cacher.default.name = node['apt']['cacher_ipaddress']
     cacher.default.ipaddress = node['apt']['cacher_ipaddress']
     cacher.default.apt.cacher_port = node['apt']['cacher_port']
-    cacher.default.apt_cacher_interface = node['apt']['cacher_interface']
+    cacher.default.apt.cacher_interface = node['apt']['cacher_interface']
     cacher.default.apt.cacher_ssl_support = node['apt']['cacher_ssl_support']
     servers << cacher
   elsif node['apt']['caching_server']

--- a/templates/default/01proxy.erb
+++ b/templates/default/01proxy.erb
@@ -1,5 +1,9 @@
 Acquire::http::Proxy "http://<%= @proxy %>:<%= @port %>";
+<% if @proxy_ssl %>
+Acquire::https::Proxy "http://<%= @proxy %>:<%= @port %>";
+<% else %>
 Acquire::https::Proxy "DIRECT";
+<% end %>
 <% @bypass.each do |bypass, type| %>
 Acquire::<%= type %>::Proxy::<%= bypass %> "DIRECT";
 <% end %>


### PR DESCRIPTION
This is to allow for non-apt-cacher caching servers (i.e. squid) that may be put in place as a simple apt proxy.  Since squid properly supports HTTPS proxying via the CONNECT method, we can continue to proxy our apt requests through our proxy server.

As to why you would want to do this: if you have a proxy set up as an ACL filter, this allows you to use it for all of apt, rather than just plaintext sources.