### PR TITLE
Changes mailutils to bsd-mailx

### DIFF
--- a/recipes/unattended-upgrades.rb
+++ b/recipes/unattended-upgrades.rb
@@ -29,7 +29,7 @@ package 'unattended-upgrades' do
 end
 
 if node['apt']['unattended_upgrades']['mail']
-  package 'mailutils'
+  package 'bsd-mailx'
 end
 
 template '/etc/apt/apt.conf.d/20auto-upgrades' do


### PR DESCRIPTION
bsd-mailx should be favored to mailutils, since it's less overweight and
more probable to be present on the system.

mailutils depends on mysql-common and a load of (uncommon?) libraries. bsd-mailx
does not.