### PR TITLE
Fix attribute and platform name

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -54,5 +54,5 @@ suites:
     attributes:
       apt:
         unattended_upgrades:
-          enabled: true
+          enable: true
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,7 +12,7 @@ platforms:
     run_list: apt::default
   - name: ubuntu-13.10
     run_list: apt::default
-  - name: ubuntu-14.0.4
+  - name: ubuntu-14.04
     run_list: apt::default
 
 suites:

--- a/templates/default/20auto-upgrades.erb
+++ b/templates/default/20auto-upgrades.erb
@@ -1,2 +1,2 @@
 APT::Periodic::Update-Package-Lists "<%= node['apt']['unattended_upgrades']['update_package_lists'] ? 1 : 0 %>";
-APT::Periodic::Unattended-Upgrade "<%= node['apt']['unattended_upgrades']['enabled'] ? 1 : 0 %>";
+APT::Periodic::Unattended-Upgrade "<%= node['apt']['unattended_upgrades']['enable'] ? 1 : 0 %>";


### PR DESCRIPTION
In attributes/default.rb and templates/default/unattended-upgrades.seed.erb the attribut is ['apt']['unattended_upgrades']['enable'], in templates/default/20auto-upgrades.erb and .kitchen.yml the attribute was ['apt']['unattended_upgrades']['enabled']. Also the platform name of Ubuntu 14.04 was wrong.