### PR TITLE
Allow for default keyserver behavior to work on tcp/80.

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -29,7 +29,7 @@ def install_key_from_keyserver(key, keyserver)
     if !node['apt']['key_proxy'].empty?
       command "apt-key adv --keyserver-options http-proxy=#{node['apt']['key_proxy']} --keyserver hkp://#{keyserver}:80 --recv #{key}"
     else
-      command "apt-key adv --keyserver #{keyserver} --recv #{key}"
+      command "apt-key adv --keyserver hkp://#{keyserver}:80 --recv #{key}"
     end
     action :run
     not_if do


### PR DESCRIPTION
Most keyservers, notably Ubuntu and Debian, allow for hkp traffic on
tcp/80 in addition to the default of tcp/11371.

For those of us behind draconian firewalls but dont have a
proxy to send all the traffic though, this is helpful when firewalls
block keyserver traffic.  Because security.