### PR TITLE
Replace update-notifier-common with our own logic

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,6 +30,7 @@ first_run_file = File.join(Chef::Config[:file_cache_path], "apt_compile_time_upd
 file '/var/lib/apt/periodic/update-success-stamp' do
   owner 'root'
   group 'root'
+  only_if { apt_installed? }
   action :nothing
 end
 


### PR DESCRIPTION
update-notifier-common is no longer available in Debian 8 (Jessie). As such, we update the timestamp file ourselves when running `apt-get update`.

This pull request is meant as an alternative to #115. Compared to this, my variant is more explicit regarding when to update the timestamp file. This makes the behavior more predictable for chef. However, as we are not as strongly tied to the apt internals, this *might* lead to more update runs than strictly necessary if `apt-get update` is performed outside of a chef run.

But at least, we are sure that our own state is always up-to-date following our rules.
