### PR TITLE
fix typo in attribute

### DIFF
--- a/templates/default/20auto-upgrades.erb
+++ b/templates/default/20auto-upgrades.erb
@@ -1,2 +1,2 @@
 APT::Periodic::Update-Package-Lists "<%= node['apt']['unattended_upgrades']['update_package_lists'] ? 1 : 0 %>";
-APT::Periodic::Unattended-Upgrade "<%= node['apt']['unattended_upgrades']['enabled'] ? 1 : 0 %>";
+APT::Periodic::Unattended-Upgrade "<%= node['apt']['unattended_upgrades']['enable'] ? 1 : 0 %>";


### PR DESCRIPTION
everywhere else this is 'enable', typo'd in this file as 'enabled'.