### PR TITLE
Extract gpg ids fails when locale is not en-XX #117

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -42,7 +42,7 @@ end
 
 # run command and extract gpg ids
 def extract_fingerprints_from_cmd(cmd)
-  so = Mixlib::ShellOut.new(cmd)
+  so = Mixlib::ShellOut.new("LANG=en_US #{cmd}")
   so.run_command
   so.stdout.split(/\n/).map do |t|
     if z = t.match(/^ +Key fingerprint = ([0-9A-F ]+)/)


### PR DESCRIPTION
  obvious fix.