### PR TITLE
Fix attributes typo: unattended_upgrades->enabled

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,7 +29,7 @@ default['apt']['key_proxy'] = ''
 default['apt']['cache_bypass'] = {}
 default['apt']['periodic_update_min_delay'] = 86_400
 default['apt']['launchpad_api_version'] = '1.0'
-default['apt']['unattended_upgrades']['enable'] = false
+default['apt']['unattended_upgrades']['enabled'] = false
 default['apt']['unattended_upgrades']['update_package_lists'] = true
 # this needs a good default
 codename = node.attribute?('lsb') ? node['lsb']['codename'] : 'notlinux'


### PR DESCRIPTION
The template uses [`note['apt']['unattended_upgrades']['enabled']`](https://github.com/opscode-cookbooks/apt/blob/d9da7847c58d156ad1e24021d49511efdce0394d/templates/default/20auto-upgrades.erb#L2).