### PR TITLE
Work-around for apt-key behind fascist firewalls

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -29,7 +29,7 @@ def install_key_from_keyserver(key, keyserver)
     if !node['apt']['key_proxy'].empty?
       command "apt-key adv --keyserver-options http-proxy=#{node['apt']['key_proxy']} --keyserver hkp://#{keyserver}:80 --recv #{key}"
     else
-      command "apt-key adv --keyserver #{keyserver} --recv #{key}"
+      command "apt-key adv --keyserver hkp://#{keyserver}:80 --recv #{key}"
     end
     action :run
     not_if do


### PR DESCRIPTION
This is the same as #118, but I have a signed CLA.