### PR TITLE
Adds key_proxy as LWRP attribute for apt_repository #134

### DIFF
--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -34,6 +34,7 @@ state_attrs :arch,
             :distribution,
             :key,
             :keyserver,
+            :key_proxy,
             :repo_name,
             :trusted,
             :uri
@@ -49,6 +50,7 @@ attribute :trusted, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :deb_src, :default => false
 attribute :keyserver, :kind_of => String, :default => nil
 attribute :key, :kind_of => String, :default => nil
+attribute :key_proxy, :kind_of => String, :default => node[:apt][:key_proxy]
 attribute :cookbook, :kind_of => String, :default => nil
 # trigger cache rebuild
 # If not you can trigger in the recipe itself after checking the status of resource.updated{_by_last_action}?


### PR DESCRIPTION
Addresses https://github.com/opscode-cookbooks/apt/issues/134

* adds missing `key_proxy` LWRP attribute to apt_repository
* LWRP attribute defaults to `node['apt']['key_proxy']` for backwards compatibility

Existing cookbooks that are relying on setting the undocumented `node['apt']['key_proxy']` attribute will continue to work as-is.

I didn't add the missing documentation for overriding `node['apt']['key_proxy']` but can add that to this pull request if desired...