### PR TITLE
Avoid non JSON safe characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,17 +103,17 @@ Attributes
 ### Unattended Upgrades
 
 * `['apt']['unattended_upgrades']['enable']` - enables unattended upgrades, default is false
-* `['apt']['unattended_upgrades']['update_package_lists']` — automatically update package list (`apt-get update`) daily, default is true
-* `['apt']['unattended_upgrades']['allowed_origins']` — array of allowed apt origins from which to pull automatic upgrades, defaults to a guess at the system's main origin and should almost always be overridden
-* `['apt']['unattended_upgrades']['package_blacklist']` — an array of package which should never be automatically upgraded, defaults to none
-* `['apt']['unattended_upgrades']['auto_fix_interrupted_dpkg']` — attempts to repair dpkg state with `dpkg --force-confold --configure -a` if it exits uncleanly, defaults to false (contrary to the unattended-upgrades default)
-* `['apt']['unattended_upgrades']['minimal_steps']` — Split the upgrade into the smallest possible chunks. This makes the upgrade a bit slower but it has the benefit that shutdown while a upgrade is running is possible (with a small delay). Defaults to false.
-* `['apt']['unattended_upgrades']['install_on_shutdown']` — Install upgrades when the machine is shuting down instead of doing it in the background while the machine is running. This will (obviously) make shutdown slower. Defaults to false.
-* `['apt']['unattended_upgrades']['mail']` — Send email to this address for problems or packages upgrades. Defaults to no email.
-* `['apt']['unattended_upgrades']['mail_only_on_error']` — If set, email will only be set on upgrade errors. Otherwise, an email will be sent after each upgrade. Defaults to true.
+* `['apt']['unattended_upgrades']['update_package_lists']` - automatically update package list (`apt-get update`) daily, default is true
+* `['apt']['unattended_upgrades']['allowed_origins']` - array of allowed apt origins from which to pull automatic upgrades, defaults to a guess at the system's main origin and should almost always be overridden
+* `['apt']['unattended_upgrades']['package_blacklist']` - an array of package which should never be automatically upgraded, defaults to none
+* `['apt']['unattended_upgrades']['auto_fix_interrupted_dpkg']` - attempts to repair dpkg state with `dpkg --force-confold --configure -a` if it exits uncleanly, defaults to false (contrary to the unattended-upgrades default)
+* `['apt']['unattended_upgrades']['minimal_steps']` - Split the upgrade into the smallest possible chunks. This makes the upgrade a bit slower but it has the benefit that shutdown while a upgrade is running is possible (with a small delay). Defaults to false.
+* `['apt']['unattended_upgrades']['install_on_shutdown']` - Install upgrades when the machine is shuting down instead of doing it in the background while the machine is running. This will (obviously) make shutdown slower. Defaults to false.
+* `['apt']['unattended_upgrades']['mail']` - Send email to this address for problems or packages upgrades. Defaults to no email.
+* `['apt']['unattended_upgrades']['mail_only_on_error']` - If set, email will only be set on upgrade errors. Otherwise, an email will be sent after each upgrade. Defaults to true.
 * `['apt']['unattended_upgrades']['remove_unused_dependencies']` Do automatic removal of new unused dependencies after the upgrade. Defaults to false.
-* `['apt']['unattended_upgrades']['automatic_reboot']` — Automatically reboots *without confirmation* if a restart is required after the upgrade. Defaults to false.
-* `['apt']['unattended_upgrades']['dl_limit']` — Limits the bandwidth used by apt to download packages. Value given as an integer in kb/sec. Defaults to nil (no limit).
+* `['apt']['unattended_upgrades']['automatic_reboot']` - Automatically reboots *without confirmation* if a restart is required after the upgrade. Defaults to false.
+* `['apt']['unattended_upgrades']['dl_limit']` - Limits the bandwidth used by apt to download packages. Value given as an integer in kb/sec. Defaults to nil (no limit).
 
 Libraries
 ---------


### PR DESCRIPTION
Avoid non JSON safe characters, which may trigger: https://tickets.opscode.com/browse/COOK-522 - previously signed CLA. Looks like regression from #123 ; and relates to https://github.com/berkshelf/berkshelf-api/issues/112

```
$ grep -R --color='auto' -P -n "[\x80-\xFF]" berks-cookbooks
berks-cookbooks/apt/README.md:108:* `['apt']['unattended_upgrades']['update_package_lists']` — automatically update package list (`apt-get update`) daily, default is true
berks-cookbooks/apt/README.md:110:* `['apt']['unattended_upgrades']['package_blacklist']` — an array of package which should never be automatically upgraded, defaults to none
berks-cookbooks/apt/README.md:111:* `['apt']['unattended_upgrades']['auto_fix_interrupted_dpkg']` — attempts to repair dpkg state with `dpkg --force-confold --configure -a` if it exits uncleanly, defaults to false (contrary to the unattended-upgrades default)
berks-cookbooks/apt/README.md:112:* `['apt']['unattended_upgrades']['minimal_steps']` — Split the upgrade into the smallest possible chunks. This makes the upgrade a bit slower but it has the benefit that shutdown while a upgrade is running is possible (with a small delay). Defaults to false.
berks-cookbooks/apt/README.md:115:* `['apt']['unattended_upgrades']['mail_only_on_error']` — If set, email will only be set on upgrade errors. Otherwise, an email will be sent after each upgrade. Defaults to true.
berks-cookbooks/apt/README.md:118:* `['apt']['unattended_upgrades']['dl_limit']` — Limits the bandwidth used by apt to download packages. Value given as an integer in kb/sec. Defaults to nil (no limit).
berks-cookbooks/apt/metadata.json:4:  "long_description": "apt Cookbook\n============\n[![Gitter](https://badge
```