### PR TITLE
Execute apt-get-update-periodic on compile time if node['apt']['compile_time_update'] is true

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -90,7 +90,7 @@ execute 'apt-get autoclean' do
   action :nothing
 end
 
-execute 'apt-get-update-periodic' do
+periodic_update = execute 'apt-get-update-periodic' do
   command 'apt-get update'
   ignore_failure true
   only_if do
@@ -100,6 +100,7 @@ execute 'apt-get-update-periodic' do
   end
   notifies :touch, 'file[/var/lib/apt/periodic/update-success-stamp]', :immediately
 end
+periodic_update.run_action(:run) if node['apt']['compile_time_update']
 
 %w(/var/cache/local /var/cache/local/preseeding).each do |dirname|
   directory dirname do


### PR DESCRIPTION
This pull request adds the compile logic to resource `execute[apt-get-update-periodic]`, similar to what is done in `bash[apt-get-update at compile time]`.

I looked for tests on compile time, but I didn't find any and I don't know how to write those. Some guidance would be necessary to write tests for this PR.

#### Background
I was expecting Chef to run `apt-get update` to fix a broken APT configuration on compile time, but even with the `compile_time_update` node attribute set to `true` it is not updating in compile time.

Right after my `include_recipe "apt::default"` there is `include_recipe 'build-essential::default'`, which installs packages in compile time, but since the apt conf wasn't fixed yet by `apt` cookbook, it failed and Chef aborted.


