### PR TITLE
Add example for enabling multiverse repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,17 @@ apt_repository 'zenoss' do
 end
 ```
 
+Enable Ubuntu [multiverse](https://help.ubuntu.com/community/Repositories/Ubuntu) repositories:
+
+```ruby
+apt_repository 'security-ubuntu-multiverse' do
+  uri        'http://security.ubuntu.com/ubuntu'
+  distribution 'trusty-security'
+  components ['multiverse']
+  deb_src 'true'
+end
+```
+
 Add the Nginx PPA, autodetect the key and repository url:
 
 ```ruby


### PR DESCRIPTION
Apart from external PPA repositories, I think it would be very useful if there was an example how someone can enable Ubuntu `multiverse` repositories with `apt` cookbook.