### PR TITLE
Fix for Chef 11 not supporting issues_url and source_url

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,8 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Configures apt and apt services and LWRPs for managing apt repositories and preferences'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-issues_url        'https://github.com/opscode-cookbooks/apt/issues'
-source_url        'https://github.com/opscode-cookbooks/apt'
+issues_url        'https://github.com/opscode-cookbooks/apt/issues' if respond_to?(:issues_url)
+source_url        'https://github.com/opscode-cookbooks/apt' if respond_to?(:source_url)
 version           '2.8.1'
 recipe            'apt', 'Runs apt-get update during compile phase and sets up preseed directories'
 recipe            'apt::cacher-ng', 'Set up an apt-cacher-ng caching proxy'


### PR DESCRIPTION
issues_url and source_url defined in metadata.rb "breaking" chef 11

```
Fetching 'apt' from git@github.com:opscode-cookbooks/apt.git (at master)
STDERR: Ridley::Errors::FromFileParserError Could not parse `/tmp/d20150820-12714-1cn8vvo/metadata.rb': undefined method `issues_url' for #<Ridley::Chef::Cookbook::Metadata:0x007f5e9ecd5538>
```