### PR TITLE
Add ability to suppress sensitive information when using `apt_repository` resource.

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -33,6 +33,7 @@ def install_key_from_keyserver(key, keyserver, key_proxy)
     else
       command "apt-key adv --keyserver-options http-proxy=#{key_proxy} --keyserver hkp://#{keyserver}:80 --recv #{key}"
     end
+    sensitive new_resource.sensitive if respond_to?(:sensitive)
     action :run
     not_if do
       key_present = extract_fingerprints_from_cmd('apt-key finger').any? do |fingerprint|
@@ -88,6 +89,7 @@ def install_key_from_uri(uri)
     remote_file cached_keyfile do
       source new_resource.key
       mode 00644
+      sensitive new_resource.sensitive if respond_to?(:sensitive)
       action :create
     end
   else
@@ -95,6 +97,7 @@ def install_key_from_uri(uri)
       source new_resource.key
       cookbook new_resource.cookbook
       mode 00644
+      sensitive new_resource.sensitive if respond_to?(:sensitive)
       action :create
     end
 
@@ -107,6 +110,7 @@ def install_key_from_uri(uri)
 
   execute "install-key #{key_name}" do
     command "apt-key add #{cached_keyfile}"
+    sensitive new_resource.sensitive if respond_to?(:sensitive)
     action :run
     not_if do
       installed_keys = extract_fingerprints_from_cmd('apt-key finger')
@@ -191,6 +195,7 @@ action :add do
   execute 'apt-get update' do
     command "apt-get update -o Dir::Etc::sourcelist='sources.list.d/#{new_resource.name}.list' -o Dir::Etc::sourceparts='-' -o APT::Get::List-Cleanup='0'"
     ignore_failure true
+    sensitive new_resource.sensitive if respond_to?(:sensitive)
     action :nothing
     notifies :run, 'execute[apt-cache gencaches]', :immediately
   end
@@ -222,6 +227,7 @@ action :add do
     group 'root'
     mode 00644
     content repository
+    sensitive new_resource.sensitive if respond_to?(:sensitive)
     action :create
     notifies :delete, 'file[/var/lib/apt/periodic/update-success-stamp]', :immediately
     notifies :run, 'execute[apt-get update]', :immediately if new_resource.cache_rebuild
@@ -232,6 +238,7 @@ action :remove do
   if ::File.exist?("/etc/apt/sources.list.d/#{new_resource.name}.list")
     Chef::Log.info "Removing #{new_resource.name} repository from /etc/apt/sources.list.d/"
     file "/etc/apt/sources.list.d/#{new_resource.name}.list" do
+      sensitive new_resource.sensitive if respond_to?(:sensitive)
       action :delete
     end
   end

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -37,7 +37,8 @@ state_attrs :arch,
             :key_proxy,
             :repo_name,
             :trusted,
-            :uri
+            :uri,
+            :sensitive
 
 # name of the repo, used for source.list filename
 attribute :repo_name, :kind_of => String, :name_attribute => true, :regex => [/^([a-z]|[A-Z]|[0-9]|_|-|\.)+$/]
@@ -55,3 +56,5 @@ attribute :cookbook, :kind_of => String, :default => nil
 # trigger cache rebuild
 # If not you can trigger in the recipe itself after checking the status of resource.updated{_by_last_action}?
 attribute :cache_rebuild, :kind_of => [TrueClass, FalseClass], :default => true
+# Hide content of the source file, don't show output for commands being run, etc.
+attribute :sensitive, :kind_of => [TrueClass, FalseClass], :default => false

--- a/test/fixtures/cookbooks/apt_test/recipes/lwrps.rb
+++ b/test/fixtures/cookbooks/apt_test/recipes/lwrps.rb
@@ -65,6 +65,17 @@ apt_repository 'nginx' do
   deb_src true
 end
 
+# Apt repository that suppresses output for sensitive resources.
+apt_repository 'haproxy' do
+  uri 'http://ppa.launchpad.net/vbernat/haproxy-1.5/ubuntu'
+  distribution node['lsb']['codename']
+  components ['main']
+  keyserver 'keyserver.ubuntu.com'
+  key '1C61B9CD'
+  sensitive true
+  action :add
+end
+
 package 'nginx-debug' do
   action :upgrade
 end
@@ -108,4 +119,3 @@ end
 apt_preference 'camel' do
   action :remove
 end
-

--- a/test/integration/lwrps/serverspec/lwrps_spec.rb
+++ b/test/integration/lwrps/serverspec/lwrps_spec.rb
@@ -28,6 +28,10 @@ describe 'apt_test::lwrps' do
     expect(file('/etc/apt/sources.list.d/nodejs.list')).to exist
   end
 
+  it 'creates the HAProxy sources.list' do
+    expect(file('/etc/apt/sources.list.d/haproxy.list')).to exist
+  end
+
   it 'creates a repo with a url that is already quoted' do
     src = 'deb\s+\"http://ppa.launchpad.net/juju/stable/ubuntu\" trusty main'
     expect(file('/etc/apt/sources.list.d/juju.list').content).to match(/#{src}/)


### PR DESCRIPTION
This is to add suppression to as many resources as possible that support the
`sensitive` attribute in the underlying provider.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>