### PR TITLE
Tidy up the apt-get update logic

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,8 +13,8 @@ platforms:
     run_list: apt::default
   - name: ubuntu-14.04
     run_list: apt::default
-#  - name: ubuntu-15.04
-#    run_list: apt::default
+  - name: ubuntu-15.04
+    run_list: apt::default
 
 suites:
   - name: default
@@ -38,6 +38,13 @@ suites:
         cacher_port: '9876'
         cacher_interface: 'eth0'
         compiletime: true
+
+  - name: compile_time
+    run_list:
+      - recipe[apt::default]
+    attributes:
+      apt:
+        compile_time_update: true
 
   - name: lwrps
     run_list:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ v2.9.0 (Unreleased)
 -------------------
 - Add `sensitive` flag for apt\_repositories
 - Enable installation of recommended or suggested packages
+- Tidy up `apt-get update` logic
 
 v2.8.2 (2015-08-24)
 -------------------

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -27,6 +27,18 @@ module Apt
       !which('apt-get').nil?
     end
 
+    # Determines whether we need to run `apt-get update`
+    #
+    # @return [Boolean]
+    def apt_up_to_date?
+      if ::File.exist?('/var/lib/apt/periodic/update-success-stamp') &&
+          ::File.mtime('/var/lib/apt/periodic/update-success-stamp') > Time.now - node['apt']['periodic_update_min_delay']
+        true
+      else
+        false
+      end
+    end
+
     # Finds a command in $PATH
     #
     # @return [String, nil]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,7 +35,7 @@ file '/var/lib/apt/periodic/update-success-stamp' do
 end
 
 # If compile_time_update run apt-get update at compile time
-if node['apt']['compile_time_update'] && (!::File.exist?('/var/lib/apt/periodic/update-success-stamp') || !::File.exist?(first_run_file))
+if node['apt']['compile_time_update'] && (!apt_up_to_date? || !::File.exist?(first_run_file))
   e = bash 'apt-get-update at compile time' do
     code <<-EOH
       apt-get update
@@ -56,15 +56,6 @@ end
 
 cookbook_file '/etc/apt/apt.conf.d/15update-stamp' do
   source '15update-stamp'
-end
-
-# Run apt-get update to create the stamp file
-execute 'apt-get-update' do
-  command 'apt-get update'
-  ignore_failure true
-  only_if { apt_installed? }
-  not_if { ::File.exist?('/var/lib/apt/periodic/update-success-stamp') }
-  notifies :touch, 'file[/var/lib/apt/periodic/update-success-stamp]', :immediately
 end
 
 # For other recipes to call to force an update
@@ -93,11 +84,8 @@ end
 execute 'apt-get-update-periodic' do
   command 'apt-get update'
   ignore_failure true
-  only_if do
-    apt_installed? &&
-      ::File.exist?('/var/lib/apt/periodic/update-success-stamp') &&
-      ::File.mtime('/var/lib/apt/periodic/update-success-stamp') < Time.now - node['apt']['periodic_update_min_delay']
-  end
+  only_if { apt_installed? }
+  not_if { apt_up_to_date? }
   notifies :touch, 'file[/var/lib/apt/periodic/update-success-stamp]', :immediately
 end
 

--- a/test/integration/compile_time/serverspec/default_spec.rb
+++ b/test/integration/compile_time/serverspec/default_spec.rb
@@ -1,0 +1,9 @@
+require_relative './spec_helper'
+
+describe 'apt::default' do
+  describe file('/tmp/kitchen/cache/apt_compile_time_update_first_run') do
+    it 'exists' do
+      expect(subject).to exist
+    end
+  end
+end


### PR DESCRIPTION
This lets us clobber an `apt-get update` call as well.
CC @lamont-granquist @jtimberman , Fixes #140